### PR TITLE
allow directory and file source paths

### DIFF
--- a/HashCopy/Private/Get-DestinationFilePath.ps1
+++ b/HashCopy/Private/Get-DestinationFilePath.ps1
@@ -7,7 +7,7 @@ function Get-DestinationFilePath {
             The file to modify.
 
         .PARAMETER Source
-            The source path (this should form part of the base path of the -File).
+            The source directory or file path.
 
         .PARAMETER Destination
             The destination path.
@@ -29,6 +29,10 @@ function Get-DestinationFilePath {
         [String]
         $Destination
     )
+
+    if (Test-Path -Path $Source -PathType leaf) {
+        $Source = Join-Path (Split-Path -Parent $Source) -ChildPath '/'
+    }
 
     $DestFile = Join-Path (Split-Path -Parent $File) -ChildPath '/'
     $DestFile = $DestFile -Replace "^$([Regex]::Escape((Convert-Path $Source)))", $Destination


### PR DESCRIPTION
Making the change above allows for the main Copy-FileHash function to accept an array of file paths rather than just directory paths. E.g.:

```
# files to copy
$SourceFiles = @()
$SourceFilesFilter = @("*.ZIP")
$SourceDirectories = @($DATSourceDirectory)

$SourceDirectories | ForEach-Object {
    $SourceFiles += (Get-ChildItem -Path $_ -Recurse -Include $SourceFilesFilter -File).FullName
}

# copy files from source to temp
Copy-FileHash -Path $SourceFiles -Destination $DATTempDirectory
```